### PR TITLE
docs: fix various broken links

### DIFF
--- a/community-membership.md
+++ b/community-membership.md
@@ -13,7 +13,7 @@ This doc outlines the various responsibilities of contributor roles in HAMi.
 | Approver   | Contributions acceptance approval                             | Highly experienced active reviewer and contributor to a subproject | [OWNERS] file approver entry |
 | Maintainer | Demonstrated responsibility and excellent technical judgement | Demonstrated responsibility and excellent technical judgement      | [Maintainers] file entry     |
 
-**Note :** It is mandatory for all HAMi community members to follow HAMi [Code of Conduct](./CODE_OF_CONDUCT.md).
+**Note :** It is mandatory for all HAMi community members to follow HAMi [Code of Conduct](./CODE-OF-CONDUCT.md).
 
 ## New contributors
 
@@ -188,6 +188,6 @@ Involuntary removal/demotion of a contributor happens when responsibilities and 
 Involuntary removal or demotion is handled through a vote by a majority of the current Maintainers.
 
 [two-factor authentication]: https://help.github.com/articles/about-two-factor-authentication
-[OWNERS]: /contributors/guide/owners.md
-[New contributors]: /contributors/guide/CONTRIBUTING.md
+[OWNERS]: https://github.com/Project-HAMi/HAMi/blob/master/OWNERS
+[New contributors]: /contributing.md
 [Maintainers]: https://github.com/Project-HAMi/HAMi/blob/master/MAINTAINERS.md

--- a/contributing.md
+++ b/contributing.md
@@ -20,7 +20,7 @@ Welcome to HAMi!
 
 ## Code of Conduct
 
-Please make sure to read and observe our [Code of Conduct](/CODE_OF_CONDUCT.md).
+Please make sure to read and observe our [Code of Conduct](/CODE-OF-CONDUCT.md).
 
 ## Community Expectations
 

--- a/governance.md
+++ b/governance.md
@@ -33,7 +33,7 @@ The HAMi and its leadership embrace the following values:
 
 ## Membership
 
-The [Community Membership](./CONTRIBUTOR-LADDER.md)
+The [Community Membership](./community-membership.md)
 
 Currently, the maintainers are the governing body for the project. This may
 change as the community grows, such as by adopting an elected steering committee.


### PR DESCRIPTION
/kind documentation

## Summary

Fix some broken links similar to https://github.com/Project-HAMi/HAMi/pull/907

## Details

links that were renamed:
- `CONTRIBUTOR_LADDER.md` -> `community-membership.md` as changed in https://github.com/Project-HAMi/community/commit/a557d69e4d4c42656ce6bef3c3e0043fc78b4944 / #7
- `CODE_OF_CONDUCT.md` -> `CODE-OF-CONDUCT.md` as changed in https://github.com/Project-HAMi/community/commit/fcb1d1cd86c5d7d296fdd18364df1b70a9e96135 / #8

links that were non-existent:
- `/contributors/guide/owners.md` -> https://github.com/Project-HAMi/HAMi/blob/master/OWNERS
- `/contributors/guide/CONTRIBUTING.md` -> `/contributing.md`