### PR TITLE
docs: add community contribution templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,32 @@
+---
+name: Bug Report
+about: Report a problem encountered while using HAMi community repository
+labels: bug
+---
+
+<!-- Please use this template while reporting a bug and provide as much info as possible. Not doing so may result in your bug not being addressed in a timely manner. Thanks!
+-->
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+- Link to the affected document, section, meeting, event, or membership guidance
+- The expected wording or process
+- A minimal screenshot or rendered excerpt, if formatting is affected
+- Related issue, pull request, meeting, or event references
+
+Before posting, remove or mask credentials, access tokens, private contact information, meeting credentials, and unrelated personal data.
+
+**Environment**:
+- Affected document or directory:
+- Repository version or commit:
+- Rendered page or source Markdown involved:
+- Browser and version, if rendering is affected:
+- Language or locale, if applicable:
+- Related community process or document:
+- Others:

--- a/.github/ISSUE_TEMPLATE/enhancement.md
+++ b/.github/ISSUE_TEMPLATE/enhancement.md
@@ -1,0 +1,13 @@
+---
+name: Enhancement Request
+about: Suggest an improvement to HAMi community repository
+labels: enhancement
+---
+
+<!-- Please use this template for enhancement and feature requests. -->
+
+**What would you like to be added**:
+
+**Why is this needed**:
+
+**Additional context**:

--- a/.github/ISSUE_TEMPLATE/good-first.md
+++ b/.github/ISSUE_TEMPLATE/good-first.md
@@ -1,0 +1,19 @@
+---
+name: Good First Issue
+about: Publish a task suitable for a first-time contributor
+labels: "good first issue"
+---
+
+<!-- Please use this template when publishing a good first issue. -->
+
+**Task description**:
+
+**Suggested solution**:
+
+**Files or components involved**:
+
+**Acceptance criteria**:
+
+**Additional context**:
+
+Contributors: reply below before starting so a maintainer can assign the issue and confirm the intended approach.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,20 @@
+---
+name: Question
+about: Ask a question about HAMi community repository
+labels: question
+---
+
+**Please provide a detailed description of your question**:
+
+**What have you already tried or investigated?**:
+
+Before posting, remove or mask credentials, access tokens, private contact information, meeting credentials, and unrelated personal data.
+
+**Environment**:
+- Affected document or directory:
+- Repository version or commit:
+- Rendered page or source Markdown involved:
+- Browser and version, if rendering is affected:
+- Language or locale, if applicable:
+- Related community process or document:
+- Others:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+**What type of PR is this?**
+
+<!--
+Add one of the following kinds:
+/kind bug
+/kind cleanup
+/kind deprecation
+/kind design
+/kind documentation
+/kind failing-test
+/kind feature
+/kind flake
+-->
+
+**What this PR does / why we need it**:
+
+**Which issue(s) this PR fixes**:
+Fixes #
+
+**Special notes for your reviewer**:
+
+**Does this PR introduce a user-facing change?**:
+
+**AI Disclosure**:
+
+<!-- Briefly disclose any AI assistance used. Do not add AI co-author or assistance trailers to commits. -->


### PR DESCRIPTION
**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:

Adds minimal issue and pull request templates tailored to HAMi community repository. The bug and question templates request relevant diagnostics while guiding reporters to minimize and mask sensitive data.

**Which issue(s) this PR fixes**:
Fixes #47

**Special notes for your reviewer**:

Documentation-only change. The five templates were checked for valid frontmatter, whitespace errors, repository-specific environment fields, and data-minimization guidance.

**Does this PR introduce a user-facing change?**:

Yes. Contributors receive structured issue and pull request templates.

**AI Disclosure**:

AI was used only for formatting purposes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added templates for bug reports, enhancement requests, questions, and beginner-friendly tasks.
  * Added prompts for reproduction steps, context, acceptance criteria, environment details, and privacy guidance.
  * Added a pull request template covering change type, linked issues, reviewer notes, user-facing impact, and AI assistance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->